### PR TITLE
Changed function declaration to expression to support polymer build

### DIFF
--- a/src/BaseFrameworkComponent.js
+++ b/src/BaseFrameworkComponent.js
@@ -31,3 +31,4 @@ class BaseGuiComponent {
         return document.createElement(this.element);
     }
 }
+window.BaseGuiComponent =BaseGuiComponent;

--- a/src/PolymerComponentFactory.js
+++ b/src/PolymerComponentFactory.js
@@ -138,3 +138,4 @@ class PolymerComponentFactory {
         return Filter;
     }
 }
+window.PolymerComponentFactory =PolymerComponentFactory;

--- a/src/PolymerFrameworkComponentWrapper.js
+++ b/src/PolymerFrameworkComponentWrapper.js
@@ -31,3 +31,4 @@ class PolymerFrameworkComponentWrapper {
         return wrapper;
     }
 }
+window.PolymerFrameworkComponentWrapper =PolymerFrameworkComponentWrapper;

--- a/src/PolymerFrameworkFactory.js
+++ b/src/PolymerFrameworkFactory.js
@@ -100,3 +100,4 @@ class PolymerFrameworkFactory {
         this._baseFrameworkFactory.setTimeout(action, timeout);
     }
 }
+window.PolymerFrameworkFactory =PolymerFrameworkFactory;


### PR DESCRIPTION
Polymer compiler is not including the native ES6 classes when compiled with ES6 build configuration.
As a result, PolymerComponentFactory and other 3 files codes are not available in the build/bundled folder causing "PolymerFrameworkFactory is not defined" error at runtime.